### PR TITLE
Fix payload returned by NetInfo.fetch

### DIFF
--- a/Libraries/Network/NetInfo.js
+++ b/Libraries/Network/NetInfo.js
@@ -185,7 +185,7 @@ var NetInfo = {
     return new Promise((resolve, reject) => {
       RCTNetInfo.getCurrentReachability(
         function(resp) {
-          resolve(resp.network_reachability);
+          resolve(resp.network_info);
         },
         reject
       );


### PR DESCRIPTION
R: @samerce @mattmo 

Fixes a regression with the payload returned by `NetInfo.fetch`.  This is actually fixed here: https://github.com/facebook/react-native/commit/53403423ca281c7961fb8b7d5e99ed04c7d65748#diff-b2ca6dcd2e267af29287d03191b8810a, but that didn't make it to the version we're tracking (v0.12).  We should consider trying an upgrade to v0.15 soon, but this should fix the issue for now.

This bug allowed the user to still interact with the app despite being offline.  This led to weird behavior like check ins "not saving"--which has been a recent complaint.  While I can't be 100% certain this was the sole cause of those issues, it is a prime suspect.  With this change, the user will be blocked from all app usage unless connected to the Internet. 
