### PR TITLE
Add transform-decorators-legacy for decorator support with babel6

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "babel-plugin-syntax-jsx": "^6.0.14",
     "babel-plugin-syntax-trailing-function-commas": "^6.0.14",
     "babel-plugin-transform-class-properties": "^6.0.14",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-es2015-arrow-functions": "^6.0.14",
     "babel-plugin-transform-es2015-block-scoping": "^6.0.18",
     "babel-plugin-transform-es2015-classes": "^6.1.2",

--- a/packager/react-packager/.babelrc
+++ b/packager/react-packager/.babelrc
@@ -7,6 +7,7 @@
     "syntax-class-properties",
     "syntax-trailing-function-commas",
     "transform-class-properties",
+    "transform-decorators-legacy",
     "transform-es2015-arrow-functions",
     "transform-es2015-block-scoping",
     "transform-es2015-classes",


### PR DESCRIPTION
R: @mattmo @samerce 

In order for our code to be compatible with the React Native 0.17 release (which uses babel6), we need to add legacy support for decorators.

For more info, see: https://phabricator.babeljs.io/T2645

Note: This is not ideal, but I think it should work since we're already using a fork of `react-native`. Ideally, babel6 will add support for decorators soon.
